### PR TITLE
Windows compilation fix: Set current line to 0 inside constructors.

### DIFF
--- a/src/include/toml.h
+++ b/src/include/toml.h
@@ -50,7 +50,7 @@ namespace ctoml {
      private:
       std::ifstream source_file_;
       char *cur_;
-      int cur_line = 0;
+      int cur_line;
 
       char cur() const { return *cur_; }
 

--- a/src/toml.cc
+++ b/src/toml.cc
@@ -82,10 +82,11 @@ std::ostream &TomlDocument::write(std::ostream &out) {
 }
 
 TomlParser::TomlParser() {
-
+   cur_line = 0;
 }
 
 TomlParser::TomlParser(std::string filename) {
+   cur_line = 0;
    open(filename);
 }
 


### PR DESCRIPTION
Visual Studio 2012 does not like initializing "TomlParser::cur_line" in the header. Put the initialization in the constructor instead.
