### PR TITLE
Close file

### DIFF
--- a/src/include/toml.h
+++ b/src/include/toml.h
@@ -99,6 +99,9 @@ namespace ctoml {
       // Open a file. Returns true if good()
       bool open(const std::string filename);
 
+      // Close file
+      void close();
+
       // Returns the number of errors
       size_t num_errors() const { return errors_.size(); }
 

--- a/src/toml.cc
+++ b/src/toml.cc
@@ -86,7 +86,7 @@ TomlParser::TomlParser() {
 }
 
 TomlParser::TomlParser(std::string filename) {
-   open(filename);
+   this->open(filename);
 }
 
 void TomlParser::error(const char *format, ...) {

--- a/src/toml.cc
+++ b/src/toml.cc
@@ -373,3 +373,7 @@ bool TomlParser::open(const std::string filename) {
 
    return source_file_.good();
 }
+
+void TomlParser::close() {
+    source_file_.close();
+}

--- a/src/toml.cc
+++ b/src/toml.cc
@@ -356,6 +356,8 @@ TomlDocument TomlParser::parse() {
       }
    }
 
+   this->close();
+
    return doc;
 }
 


### PR DESCRIPTION
Explicitly close the toml file after parsing.

Windows will prevent any process to rename/delete an opened file. Without closing the file, it will remain opened until the TomlParser object is freed/destroyed, preventing any operation on the opened file by other processes. 
